### PR TITLE
Tracking ControlledToken factory

### DIFF
--- a/networks/local.json
+++ b/networks/local.json
@@ -15,5 +15,9 @@
   "multipleWinnersProxyFactory": {
     "address": "0xBA42f54497E428b3d41280C39A94ca01830bEA57",
     "startBlock": "1"
+  },
+  "controlledTokenProxyFactory": {
+    "address": "",
+    "startBlock": "1"
   }
 }

--- a/networks/mainnet.json
+++ b/networks/mainnet.json
@@ -15,5 +15,9 @@
   "multipleWinnersProxyFactory": {
     "address": "0xBA42f54497E428b3d41280C39A94ca01830bEA57",
     "startBlock": "1"
+  },
+  "controlledTokenProxyFactory": {
+    "address": "",
+    "startBlock": "1"
   }
 }

--- a/networks/rinkeby.json
+++ b/networks/rinkeby.json
@@ -15,5 +15,9 @@
   "multipleWinnersProxyFactory": {
     "address": "0x836C94Dcb8776C679b480b38A66524f34712981a",
     "startBlock": "7687010"
+  },
+  "controlledTokenProxyFactory": {
+    "address": "0xF8D06e34Df36fB32Bb69D575AF4d17f83FE4B884",
+    "startBlock": "7687005"
   }
 }

--- a/src/mappingForControlledTokenProxyFactory.ts
+++ b/src/mappingForControlledTokenProxyFactory.ts
@@ -1,0 +1,12 @@
+import {
+    ProxyCreated,
+  } from '../generated/ControlledTokenProxyFactory/ControlledTokenProxyFactory'
+  
+import {
+    ControlledToken as ControlledTokenTemplate,
+} from '../generated/templates'
+ 
+export function handleProxyCreated(event: ProxyCreated): void {
+    ControlledTokenTemplate.create(event.params.proxy)
+}
+  

--- a/subgraph.template.yaml
+++ b/subgraph.template.yaml
@@ -62,7 +62,7 @@ dataSources:
           file: ./node_modules/@pooltogether/pooltogether-contracts/build/CompoundPrizePool.json
         - name: SingleRandomWinner
           file: ./node_modules/@pooltogether/pooltogether-contracts/build/SingleRandomWinner.json
-        - name: CompoundPrizePoolProxyFactory
+        - name: CompoundPrizePoolProxyFactory  # dont think it needs any of these apart from this one
           file: ./node_modules/@pooltogether/pooltogether-contracts/build/CompoundPrizePoolProxyFactory.json
         - name: ControlledToken
           file: ./node_modules/@pooltogether/pooltogether-contracts/build/ControlledToken.json
@@ -119,6 +119,27 @@ dataSources:
           handler: handleMultipleWinnersCreated
       file: ./src/mappingForMultipleWinners.ts
 
+
+  - name: ControlledTokenProxyFactory
+    kind: ethereum/contract
+    network: {{network}}
+    source:
+      address: "{{controlledTokenProxyFactory.address}}"
+      abi: ControlledTokenProxyFactory
+      startBlock: {{controlledTokenProxyFactory.startBlock}}
+    mapping:
+      kind: ethereum/events
+      apiVersion: 0.0.4
+      language: wasm/assemblyscript
+      entities:
+        - ControlledTokenProxyFactory
+      abis:
+        - name: ControlledTokenProxyFactory
+          file: ./node_modules/@pooltogether/pooltogether-contracts/build/ControlledTokenProxyFactory.json
+      eventHandlers:
+        - event: ProxyCreated(address)
+          handler: handleProxyCreated
+      file: ./src/mappingForControlledTokenProxyFactory.ts
 
 
 templates:


### PR DESCRIPTION
So this doesnt work as intended, queries for ControlledToken are still an empty array when a MultipleWinners Pool has been initiated. Seems like in the ProxyCreated handler we need to create a ControlledToken entity but do not have access to a lot of the info required for the entity. Should we mock these out and update them elsewhere?